### PR TITLE
feature: error-pages

### DIFF
--- a/src/site/_includes/footer-js.njk
+++ b/src/site/_includes/footer-js.njk
@@ -8,10 +8,13 @@
 </script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-<script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js"></script>
+<script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
 
 <!-- The Foundation theme JavaScript -->
-<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/libraries/foundation-6/js/foundation.min.js"></script>
-<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/foundationExtendEBI.js"></script>
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/libraries/foundation-6/js/foundation.min.js"></script>
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/foundationExtendEBI.js"></script>
 <script type="text/JavaScript">$(document).foundation();</script>
 <script type="text/JavaScript">$(document).foundationExtendEBI();</script>
+
+<!-- VF 2.0 JS -->
+<script src="https://assets.emblstatic.net/vf/v2.4.7/scripts/scripts.js"></script>

--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -9,5 +9,5 @@
   </div>
 </footer>
 
-<!-- This page was generated on {{ site.buildTime | dateDisplay('LLL d, yyyy - HH:mm') }} -->
-<script src="{{ '/scripts/srcipts.js' | url }}"></script>
+{# <!-- This page was generated on {{ site.buildTime | dateDisplay('LLL d, yyyy - HH:mm') }} --> #}
+{# <script src="{{ '/scripts/srcipts.js' | url }}"></script> #}

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -39,16 +39,9 @@
     <meta name="msapplication-TileColor" content="#2b5797" /> <!-- MS Icons -->
     <meta name="msapplication-TileImage" content="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/mstile-144x144.png" />
 
-    <!-- CSS: implied media=all -->
-    <!-- CSS concatenated and minified via ant build script-->
-
-    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/ebi-global.css" type="text/css" media="all" />
-    <link rel="stylesheet" href="https://dev.ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all" />
-
-    <!-- Use this CSS file for any custom styling -->
-    <!--
-      <link rel="stylesheet" href="css/custom.css" type="text/css" media="all" />
-    -->
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/css/ebi-global.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="https://assets.emblstatic.net/vf/v2.4.11/css/styles.css" />
 
     <!-- If you have a custom header image or colour -->
     <!--
@@ -56,24 +49,20 @@
     <meta name="ebi:masthead-image" content="//www.ebi.ac.uk/web_guidelines/EBI-Framework/images/backgrounds/embl-ebi-background.jpg" />
     -->
 
-    <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
-    <!-- also inform ES so we can host your colour palette file -->
-    <!-- <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/theme-embl-petrol.css" type="text/css" media="all" /> -->
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/theme-embl-petrol.css" type="text/css" media="all" />
     <!-- end CSS-->
-
-
   </head>
-  <body class="{{ bodyClass }}">
+  <body class="{{ bodyClass }} ebi-vf1-integration">
     <header id="masthead-black-bar" class="clearfix masthead-black-bar">
     </header>
 
     <div id="content">
-      <div data-sticky-container>
+      {# <div data-sticky-container>
         <header id="masthead" class="masthead" data-sticky data-sticky-on="large" data-top-anchor="content:top" data-btm-anchor="content:bottom">
           <div class="masthead-inner row">
             <!-- local-title -->
             <div class="columns medium-12" id="local-title">
-              <h1><a href="../../" title="Back to [service-name] homepage">EBI Framework</a></h1>
+              <h1><a href="../../" title="Back to the EMBL-EBI homepage">EMBL-EBI</a></h1>
             </div>
             <!-- /local-title -->
             <!-- local-nav -->
@@ -87,19 +76,19 @@
             <!-- /local-nav -->
           </div>
         </header>
-      </div>
+      </div> #}
       <!-- Suggested layout containers -->
       <section id="main-content-area" class="row" role="main">
-        <!-- Your menu structure should make a breadcrumb redundant, but if a breadcrump is needed uncomment the below -->
+        {# <!-- Your menu structure should make a breadcrumb redundant, but if a breadcrump is needed uncomment the below -->
         <nav aria-label="You are here:" role="navigation">
           <ul class="breadcrumbs columns">
-            <li><a href="../../">EBI Framework</a></li>
+            <li><a href="../../">EMBL-EBI</a></li>
             <li><a href="../">Sample pages</a></li>
             <li>
               <span class="show-for-sr">Current: </span> Blank boilerplate
             </li>
           </ul>
-        </nav>
+        </nav> #}
 
         <div class="columns">
           <div class="vf-grid">
@@ -122,7 +111,7 @@
     </div>
     <!-- End suggested layout containers / #content -->
 
-
+    {% include "footer-js.njk" %}
     {% include "footer.njk" %}
   </body>
 </html>

--- a/src/site/info/error-pages/403.md
+++ b/src/site/info/error-pages/403.md
@@ -1,0 +1,39 @@
+---
+title: "Error: 403"
+date: 2020-01-14 12:34:56
+subtitle: You do not have permission to access the page requested.
+layout: layouts/base.njk
+section: landing_pages
+show_title: true
+meta:
+  pagetype: 403;dimension1
+embl_content_meta_properties:
+  who: none
+  what: none
+  where: EMBL-EBI
+  active: where
+  utility: 10
+  reach: 0
+  maintainer: EMBL-EBI Web Dev
+  lastreview: 2021.04.01
+  reviewcycle: 365
+  expiry: never
+---
+
+{% render '@vf-intro', {
+  "vf_intro_badge": false,
+  "vf_intro_heading": title,
+  "vf_intro_subheading": "",
+  "vf_intro_lede": subtitle,
+  "vf_intro_text": [
+    "You may need to login, or ask the page owner for access details."
+  ]
+} %}
+
+<section class="embl-grid">
+  <div></div>
+  <div class="vf-content">
+    <h3>Need assistance?</h3>
+    <a class="vf-button vf-button--primary" href="https://www.ebi.ac.uk/support/error">Contact our support team</a>
+  </div>
+</section>

--- a/src/site/info/error-pages/404.md
+++ b/src/site/info/error-pages/404.md
@@ -1,0 +1,66 @@
+---
+title: "Error: 404"
+date: 2020-01-14 12:34:56
+subtitle: We’re sorry - we can’t find the page or file you requested.
+layout: layouts/base.njk
+section: landing_pages
+show_title: true
+meta:
+  pagetype: 404;dimension1
+embl_content_meta_properties:
+  who: none
+  what: none
+  where: EMBL-EBI
+  active: where
+  utility: 10
+  reach: 0
+  maintainer: EMBL-EBI Web Dev
+  lastreview: 2021.04.01
+  reviewcycle: 365
+  expiry: never
+---
+
+{% render '@vf-intro', {
+  "vf_intro_badge": false,
+  "vf_intro_heading": title,
+  "vf_intro_subheading": "",
+  "vf_intro_lede": subtitle,
+  "vf_intro_text": [
+    "It may have been removed, had its name changed, or be temporarily unavailable.",
+    "You might try <a href='https://www.embl.org/search'>searching for it</a>."
+  ]
+} %}
+
+<section class="embl-grid embl-grid--has-centered-content">
+  <div></div>
+  <div>
+  <form action="//www.ebi.ac.uk/ebisearch/search.ebi" class="vf-form | vf-search vf-search--inline">
+    <div class="vf-form__item | vf-search__item">
+      <input type="hidden" name="db" value="allebi">
+      <input type="hidden" name="requestFrom" value="ebi_index">
+      <label class="vf-form__label vf-u-sr-only | vf-search__label" for="text">Search</label>
+      <input type="search" id="text" name="query" class="vf-form__input | vf-search__input st-default-search-input" placeholder="Search EMBL-EBI" />
+    </div>
+    <!-- <div class="vf-form__item | vf-search__item">
+      <label class="vf-form__label vf-u-sr-only | vf-search__label" for="vf-form__select">Category</label>
+      <select class="vf-form__select" id="vf-form__select" data-embl-search-facet>
+        <option value="all" selected>Everything</option>
+        <option value="People directory">People</option>
+        <option value="Jobs">Jobs</option>
+        <option value="News">News</option>
+      </select>
+    </div> -->
+    <button type="submit" class="vf-search__button | vf-button vf-button--primary">Search</button>
+  </form>
+  </div>
+</section>
+
+
+
+<section class="embl-grid">
+  <div></div>
+  <div class="vf-content">
+    <h3>Need assistance?</h3>
+    <a class="vf-button vf-button--primary" href="https://www.ebi.ac.uk/support/error">Contact our support team</a>
+  </div>
+</section>

--- a/src/site/info/error-pages/500.md
+++ b/src/site/info/error-pages/500.md
@@ -1,0 +1,40 @@
+---
+title: "Error: 500"
+date: 2020-01-14 12:34:56
+subtitle: There was a technical error.
+layout: layouts/base.njk
+section: landing_pages
+show_title: true
+meta:
+  pagetype: 500;dimension1
+embl_content_meta_properties:
+  who: none
+  what: none
+  where: EMBL-EBI
+  active: where
+  utility: 10
+  reach: 0
+  maintainer: EMBL-EBI Web Dev
+  lastreview: 2021.04.01
+  reviewcycle: 365
+  expiry: never
+---
+
+{% render '@vf-intro', {
+  "vf_intro_badge": false,
+  "vf_intro_heading": title,
+  "vf_intro_subheading": "",
+  "vf_intro_lede": subtitle,
+  "vf_intro_text": [
+    "Something has gone wrong with our web server when attempting to make this page.",
+    "This problem means that the service you are trying to access is currently unavailable. Please try again later."
+  ]
+} %}
+
+<section class="embl-grid">
+  <div></div>
+  <div class="vf-content">
+    <h3>Need assistance?</h3>
+    <a class="vf-button vf-button--primary" href="https://www.ebi.ac.uk/support/error">Contact our support team</a>
+  </div>
+</section>

--- a/src/site/info/index.njk
+++ b/src/site/info/index.njk
@@ -1,0 +1,43 @@
+---
+title: Info overview
+subtitle: Overview of info at EMBL-EBI
+date: 2018-08-22 12:24:50
+layout: layouts/base.njk
+bodyClass: none
+meta:
+  image: https://acxngcvroo.cloudimg.io/v7/https://www.embl.org/files/wp-content/uploads/vf-hero-intense.png
+  description: "Overview of info at EMBL-EBI"
+  keywords: "admin, overview, microsite"
+  pagetype: landing;dimension1
+embl_content_meta_properties:
+  who: none 
+  what: none
+  where: EMBL-EBI
+  active: what
+  utility: 0
+  reach: 10
+  maintainer: EMBL-EBI Web Development
+  lastreview: 2021.04.01
+  reviewcycle: 365
+  expiry: never
+---
+{# Intro #}
+
+{% set context = Intro %}
+{% set vf_intro_heading = title %}
+{% set vf_intro_lede = subtitle %}
+{% include containers.intro %}
+
+{# Admin sites #}
+
+<section class="embl-grid | embl-grid--has-centered-content">
+  <div>{# empty #}</div>
+  
+  <div class="vf-content">
+    {% markdown %}
+      Nothing yet
+    {% endmarkdown %}
+  </div>
+</section>
+
+<hr class="vf-divider">

--- a/src/site/info/index.yml
+++ b/src/site/info/index.yml
@@ -1,0 +1,4 @@
+Intro:
+  vf_intro_text:
+    - 
+


### PR DESCRIPTION
Creates error pages:

-  in the same location as the embl.org ones (/info/error-pages/XXX.html)
- uses the same text as the existing EBI ones.
- uses the VF 2 with 1.x header/footer

And various updates to templates.

Current look

![image](https://user-images.githubusercontent.com/928100/113341131-16302f00-932d-11eb-9570-b7cb6a2be93e.png)

New 

![image](https://user-images.githubusercontent.com/928100/113341172-27793b80-932d-11eb-9fb7-9cef8463df34.png)

(there are a couple minor spacing things to work out, but those can follow later)