### PR TITLE
White strip issue

### DIFF
--- a/src/site/about/our-impact/index.njk
+++ b/src/site/about/our-impact/index.njk
@@ -293,13 +293,14 @@ templateEngineOverride: njk
       <style>
       body .vf-card.vf-card--by-the-numbers {
         --card-background-color: var(--vf-card-theme-color--background,none);
-        grid-template-rows: 158px repeat(3, 30px);
+        grid-template-rows: 209px 0;
       }
       .vf-card--by-the-numbers .vf-card__image {
         background-color: rgb(0, 122, 83);
         overflow: hidden;
         z-index: -2;
         position: relative;
+        aspect-ratio: var(--vf-card__image--aspect-ratio, 8/5);
       }
       .vf-card--by-the-numbers .vf-card__image .vf-card__text,
       .vf-card--by-the-numbers .vf-card__image .vf-card__title {

--- a/src/site/about/our-impact/index.njk
+++ b/src/site/about/our-impact/index.njk
@@ -236,8 +236,6 @@ templateEngineOverride: njk
                 of raw data storage
               </p>
             </div>
-            <div class="vf-card__content">
-            </div>
           </div>
 
           <div class="vf-card vf-card--by-the-numbers">
@@ -252,8 +250,6 @@ templateEngineOverride: njk
                 web requests made to our websites on an average day
               </p>
             </div>
-            <div class="vf-card__content">
-            </div>
           </div>
 
           <div class="vf-card vf-card--by-the-numbers">
@@ -266,8 +262,6 @@ templateEngineOverride: njk
               <p class="vf-card__text">
                 jointly-funded with 577 institutes from 62 countries, in 2019 alone
               </p>
-            </div>
-            <div class="vf-card__content">
             </div>
           </div>
 
@@ -282,8 +276,6 @@ templateEngineOverride: njk
                 accessed our Train online platform in 2020
               </p>
             </div>
-            <div class="vf-card__content">
-            </div>
           </div>
         </section>
       </div>
@@ -293,7 +285,6 @@ templateEngineOverride: njk
       <style>
       body .vf-card.vf-card--by-the-numbers {
         --card-background-color: var(--vf-card-theme-color--background,none);
-        grid-template-rows: 209px 0;
       }
       .vf-card--by-the-numbers .vf-card__image {
         background-color: rgb(0, 122, 83);


### PR DESCRIPTION
The root cause of this issue: 

`aspect-ratio` css style is not currently supported in non-chrome browsers. It will automatically look good in non-chromium browsers.

I removed some css that was not necessary (since its only one row), that fixes this issue.

Tested in Chrome, Firefox latest.